### PR TITLE
Glue table update

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 
+import com.amazonaws.services.glue.model.AWSGlueException;
+import com.amazonaws.services.glue.model.AlreadyExistsException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -549,7 +551,7 @@ public class TopicPartitionWriter {
     String topicName = tp.topic();
     try {
       // TRY TO TRIGGER CRAWLER AT TABLE LEVEL
-      metastore.updateMetastore(topicName, sinkRecordForSchemaChange);
+      metastore.updateMetastoreThroughCrawler(topicName);
     }
     catch (Exception e) {
 
@@ -559,7 +561,7 @@ public class TopicPartitionWriter {
         try {
           String[] parts = topicName.split("\\.");
           topicName = parts[0] + "." + parts[1];
-          metastore.updateMetastore(topicName, sinkRecordForSchemaChange);
+          metastore.updateMetastoreThroughCrawler(topicName);
         }
         catch (Exception ex) {
           log.error("Got first exception while running crawler with name: {}, e = ", topicName, e);
@@ -571,17 +573,39 @@ public class TopicPartitionWriter {
       }
     }
   }
-  
+
+  private void updateGlueTable(){
+    String topicName = tp.topic();
+    String s3PathForTable= connectorConfig.getBucketName()+"/"+topicsDir;
+    try {
+      metastore.updateMetastoreThroughGlueSdk(topicName, sinkRecordForSchemaChange, s3PathForTable,
+              globalCurrentEncodedPartition);
+    }catch (AlreadyExistsException e) {
+      log.error("Table already exists, e= ", e);
+    }
+  }
+
+  private void createGlueTablePartition() {
+    String topicName = tp.topic();
+    String s3PathForTablePartition = connectorConfig.getBucketName() + "/" + topicsDir;
+    try {
+      metastore.createPartition(topicName, s3PathForTablePartition, globalCurrentEncodedPartition);
+    } catch (AlreadyExistsException e) {
+      log.error("Partition already exists, e= ", e);
+    }
+  }
+
   private void commitFiles() {
     boolean isPartitionChanged = false;
     currentStartOffset = minStartOffset();
     try {
       for (Map.Entry<String, String> entry : commitFiles.entrySet()) {
         String encodedPartition = entry.getKey();
-        if(!isPartitionChanged && !(encodedPartition.equalsIgnoreCase(globalCurrentEncodedPartition))) {
-            isPartitionChanged = true;
-            globalCurrentEncodedPartition = encodedPartition;
-            log.info("isPartitionChanged = true, reason = encoded partition " + encodedPartition  + " does not match globalPartition " + globalCurrentEncodedPartition);
+        if (!isPartitionChanged && !(encodedPartition.equalsIgnoreCase(globalCurrentEncodedPartition))) {
+          isPartitionChanged = true;
+          log.info("isPartitionChanged = true, reason = encoded partition " + encodedPartition
+                  + " does not match globalPartition " + globalCurrentEncodedPartition);
+          globalCurrentEncodedPartition = encodedPartition;
         }
         commitFile(encodedPartition);
         if (isTaggingEnabled) {
@@ -592,17 +616,20 @@ public class TopicPartitionWriter {
         recordCounts.remove(encodedPartition);
 
         log.debug("Committed {} for {}", entry.getValue(), tp);
-        if(!schemaToBeChanged && isPartitionChanged) {
-            if(!metastore.isPartitionAvailable(tp.topic().toString(), globalCurrentEncodedPartition)) {
-                schemaToBeChanged = true;
-              log.info("schemaToBeChanged = true, reason = parition is not available " + globalCurrentEncodedPartition);
-            }
-        }
         if(schemaToBeChanged) {
-          updateMetastore();
+          updateGlueTable();
           schemaToBeChanged = false;
         }
+        if (isPartitionChanged && !metastore.isPartitionAvailable(tp.topic().toString(),
+                globalCurrentEncodedPartition)) {
+          log.info("creating new partition, reason = parition is not available " + globalCurrentEncodedPartition);
+          createGlueTablePartition();
+        }
       }
+    }  catch (AWSGlueException e){
+      log.info("Exception while updating through glue api {}, e= ", tp.topic(), e);
+      //Running glue crawler on glue api failure
+      updateMetastore();
     } catch (ConnectException e) {
       throw new RetriableException(e);
     }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -616,8 +616,8 @@ public class TopicPartitionWriter {
           schemaToBeChanged = false;
         }
         if (isPartitionChanged && !metastore.isPartitionAvailable(tp.topic().toString(),
-                globalCurrentEncodedPartition)) {
-          log.info("creating new partition, reason = parition is not available " + globalCurrentEncodedPartition);
+                encodedPartition)) {
+          log.info("creating new partition, reason = parition is not available " + encodedPartition);
           createGlueTablePartition();
         }
       }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueDataType.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueDataType.java
@@ -1,0 +1,45 @@
+package io.confluent.connect.s3.metastore;
+
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.Locale;
+
+public class GlueDataType {
+
+    public static String getDataType(Schema.Type type){
+        switch (type){
+        case INT8:
+        case INT16:
+        case INT32:
+            return Type.INT.getName();
+        case INT64:
+            return Type.BIGINT.getName();
+        case STRING:
+            return Type.STRING.getName();
+        case FLOAT32:
+            return Type.FLOAT.getName();
+        case FLOAT64:
+            return Type.DOUBLE.getName();
+        }
+        return Type.STRING.getName();
+    }
+
+    public static enum Type {
+        INT,
+        BIGINT,
+        DOUBLE,
+        FLOAT,
+        STRING,
+        BOOLEAN;
+
+        private String name;
+
+        private Type() {
+            this.name = this.name().toLowerCase(Locale.ROOT);
+        }
+
+        public String getName() {
+            return this.name;
+        }
+    }
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueDataType.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueDataType.java
@@ -1,30 +1,34 @@
 package io.confluent.connect.s3.metastore;
 
 import org.apache.kafka.connect.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Locale;
 
 public class GlueDataType {
-
-    public static String getDataType(Schema.Type type){
-        switch (type){
+    private static final Logger log = LoggerFactory.getLogger(GlueDataType.class);
+    public static String getDataType(Schema schema){
+        switch (schema.type()){
         case INT8:
         case INT16:
         case INT32:
-            return Type.INT.getName();
-        case INT64:
-            return Type.BIGINT.getName();
         case STRING:
-            return Type.STRING.getName();
+        case BOOLEAN:
         case FLOAT32:
-            return Type.FLOAT.getName();
         case FLOAT64:
-            return Type.DOUBLE.getName();
+            return getPrimitiveType(schema.type());
+        case INT64:
+            return TimestampType.TIMESTAMP.getName(schema)==null?PrimitiveType.BIGINT.getName() : TimestampType.TIMESTAMP.getName(schema);
+        case MAP:
+            return MapType.MAP.getName(schema.keySchema(), schema.valueSchema());
+        case ARRAY:
+            return ArrayType.ARRAY.getName(schema.valueSchema());
         }
-        return Type.STRING.getName();
+        return PrimitiveType.STRING.getName();
     }
 
-    public static enum Type {
+    public static enum PrimitiveType {
         INT,
         BIGINT,
         DOUBLE,
@@ -34,12 +38,90 @@ public class GlueDataType {
 
         private String name;
 
-        private Type() {
+        private PrimitiveType() {
             this.name = this.name().toLowerCase(Locale.ROOT);
+        }
+
+        PrimitiveType(String s) {
+
         }
 
         public String getName() {
             return this.name;
         }
     }
+
+    public static enum MapType {
+        MAP("map<keyType,valueType>");
+
+        public String name;
+
+        MapType(String name) {
+            this.name = name;
+        }
+
+        public String getName(Schema key, Schema value) {
+            String keyType = getPrimitiveType(key.type());
+            String valueType = getPrimitiveType(value.type());
+            log.info("keyType and valueType {}, {}", keyType, valueType );
+            log.info("name  {}", this.name );
+            this.name = this.name.replaceAll("keyType", keyType);
+            this.name = this.name.replaceAll("valueType", valueType);
+            log.info("name after {}", this.name );
+            return this.name;
+        }
+
+    }
+
+    public static enum ArrayType {
+        ARRAY("array<type>");
+
+        public String name;
+
+        ArrayType(String name) {
+            this.name = name;
+        }
+
+        public String getName(Schema value) {
+            String valueType = getPrimitiveType(value.type());
+            this.name = this.name.replaceAll("type", valueType);
+            return this.name;
+        }
+
+    }
+
+    public static enum TimestampType {
+        TIMESTAMP;
+
+        public String name;
+
+        TimestampType() {
+            this.name = this.name().toLowerCase(Locale.ROOT);
+        }
+
+        public String getName(Schema schema) {
+            return schema.name() != null && schema.name().equalsIgnoreCase("org.apache.kafka.connect.data.Timestamp") ?
+                    this.name :
+                    null;
+        }
+
+    }
+    public static String getPrimitiveType(Schema.Type t) {
+        switch (t) {
+        case INT8:
+        case INT16:
+        case INT32:
+            return PrimitiveType.INT.getName();
+        case STRING:
+            return PrimitiveType.STRING.getName();
+        case BOOLEAN:
+            return PrimitiveType.BOOLEAN.getName();
+        case FLOAT32:
+            return PrimitiveType.FLOAT.getName();
+        case FLOAT64:
+            return PrimitiveType.DOUBLE.getName();
+        }
+        return PrimitiveType.STRING.getName();
+    }
+
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
@@ -3,15 +3,15 @@ package io.confluent.connect.s3.metastore;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.amazonaws.services.glue.model.*;
+import org.apache.avro.Schema;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.glue.AWSGlue;
 import com.amazonaws.services.glue.AWSGlueClient;
-import com.amazonaws.services.glue.model.AWSGlueException;
-import com.amazonaws.services.glue.model.GetPartitionRequest;
-import com.amazonaws.services.glue.model.StartCrawlerRequest;
-import com.amazonaws.services.glue.model.StartCrawlerResult;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 
@@ -32,6 +32,64 @@ public class GlueMetastore implements IMetastore {
         StartCrawlerResult startCrawlerResult = awsGlue.startCrawler(new StartCrawlerRequest().withName(name));
         String requestId = startCrawlerResult.getSdkResponseMetadata().getRequestId();
         log.info("Running Glue crawler, name : {}, requestId = {}", name, requestId);
+    }
+
+    @Override
+    public void updateMetastore(String name, SinkRecord sinkRecord){
+        String[] parts = name.split("\\.");
+        log.info("testing update metastore");
+
+        String databaseName=parts[0];
+        String tableName= name.replace(".", "_");
+        List<Column> columns= getListOfColumns(sinkRecord);
+        StorageDescriptor storageDescriptor = new StorageDescriptor();
+        storageDescriptor.setSerdeInfo(new SerDeInfo());
+        storageDescriptor.setInputFormat("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat");
+        storageDescriptor.setOutputFormat("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat");
+        storageDescriptor.setColumns(columns);
+//        storageDescriptor.setLocation(buildS3Paths(databaseName,name));
+        if(checkIfTableExists(databaseName, tableName)){
+            log.info("Table exists");
+            awsGlue.updateTable(new UpdateTableRequest().withDatabaseName(databaseName)
+                    .withTableInput(new TableInput().withName(tableName).withStorageDescriptor(storageDescriptor)));
+        } else {
+            log.info("Table does not exists");
+            awsGlue.createTable(new CreateTableRequest().withDatabaseName(databaseName).withTableInput(
+                    new TableInput().withName(tableName)
+                            .withStorageDescriptor(storageDescriptor.withLocation(buildS3Paths(databaseName, name)))));
+        }
+    }
+
+    private String buildS3Paths(String teamName, String path) {
+        return "s3://zinka-datalake-mumbai/" + teamName + '/' + path;
+    }
+    private List<Column> getListOfColumns(SinkRecord sinkRecord) {
+        List<Column> columns= new ArrayList<>();
+        for (Field field: sinkRecord.valueSchema().fields()){
+            Column column= new Column();
+            column.setName(field.name());
+            column.setType(field.schema().type().getName());
+            columns.add(column);
+        }
+        return columns;
+    }
+
+    private boolean checkIfTableExists(String databaseName, String tableName) {
+        boolean tableExists = false;
+        try {
+
+            awsGlue.getTable(new GetTableRequest()
+                    .withDatabaseName(databaseName)
+                    .withName(tableName));
+            // If the getTable request succeeds, the table exists
+            tableExists = true;
+        } catch (Exception e) {
+            if (e instanceof EntityNotFoundException){
+                tableExists = false;
+            }
+            // If the getTable request throws a ResourceNotFoundException, the table does not exist
+        }
+        return tableExists;
     }
 
     @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
@@ -55,7 +55,7 @@ public class GlueMetastore implements IMetastore {
             if(checkIfUpdateRequired(table, tableInput)){
                 log.info("Table exists, updating table {}", tableName);
                 awsGlue.updateTable(new UpdateTableRequest().withDatabaseName(databaseName)
-                        .withTableInput(tableInput);
+                        .withTableInput(tableInput));
             }
 
         } else {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
@@ -43,14 +43,14 @@ public class GlueMetastore implements IMetastore {
         String[] parts = name.split("\\.");
         String databaseName=parts[0];
         String tableName = name.replace(".", "_");
-        List<Column>partitionKeys= getPartitionKeysUsingPartition(partition);
+        List<Column>partitionKeys = getPartitionKeysUsingPartition(partition);
         List<Column> columns = getListOfColumns(sinkRecord);
         StorageDescriptor storageDescriptor = getDefaultStorageDescriptor();
         storageDescriptor.setColumns(columns);
         storageDescriptor.setLocation(buildS3Paths(s3Path,name));
-        TableInput tableInput=new TableInput().withName(tableName).withPartitionKeys(partitionKeys)
+        TableInput tableInput = new TableInput().withName(tableName).withPartitionKeys(partitionKeys)
                 .withStorageDescriptor(storageDescriptor);
-        Table table =checkIfTableExists(databaseName, tableName);
+        Table table = checkIfTableExists(databaseName, tableName);
         if(table!=null){
             if(checkIfUpdateRequired(table, tableInput)){
                 log.info("Table exists, updating table {}", tableName);
@@ -153,8 +153,7 @@ public class GlueMetastore implements IMetastore {
 
     }
     private Boolean checkIfUpdateRequired(Table table, TableInput tableInput) {
-        if (tableInput.getStorageDescriptor().getColumns().size() != table.getStorageDescriptor().getColumns().size()
-                || tableInput.getPartitionKeys().size() != table.getPartitionKeys().size()) {
+        if (tableInput.getPartitionKeys().size() != table.getPartitionKeys().size()) {
             return true;
         }
         if (!table.getStorageDescriptor().getLocation().equals(tableInput.getStorageDescriptor().getLocation())) {
@@ -209,14 +208,12 @@ public class GlueMetastore implements IMetastore {
     }
     private List<Column> getListOfColumns(SinkRecord sinkRecord) {
         List<Column> columns= new ArrayList<>();
-//        log.info("Sink record schema {}", sinkRecord.valueSchema().fields());
         for (Field field: sinkRecord.valueSchema().fields()){
             Column column= new Column();
             column.setName(field.name());
             column.setType(GlueDataType.getDataType(field.schema()));
             columns.add(column);
         }
-//        log.info("New schema {}", columns);
         return columns;
     }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
@@ -65,7 +65,6 @@ public class GlueMetastore implements IMetastore {
     }
 
     private Boolean checkIfUpdateRequired(Table table, TableInput tableInput) {
-        log.info("Table {}", table);
         if (tableInput.getStorageDescriptor().getColumns().size() != table.getStorageDescriptor().getColumns().size()
                 || tableInput.getPartitionKeys().size() != table.getPartitionKeys().size()) {
             return true;
@@ -85,7 +84,7 @@ public class GlueMetastore implements IMetastore {
         }
         for (Column column : tableInput.getPartitionKeys()) {
             Column existingPartitionKey = partitionKeyMap.getOrDefault(column.getName(), null);
-            if (existingPartitionKey == null || existingPartitionKey.getType().equals(column.getType())) {
+            if (existingPartitionKey == null || !existingPartitionKey.getType().equals(column.getType())) {
                 return true;
             }
         }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
@@ -164,13 +164,13 @@ public class GlueMetastore implements IMetastore {
         Map<String, Column> partitionKeyMap = table.getPartitionKeys().stream()
                 .collect(Collectors.toMap(Column::getName, e -> e));
         for (Column column : tableInput.getStorageDescriptor().getColumns()) {
-            Column existingColumn = columnMap.getOrDefault(column.getName(), null);
+            Column existingColumn = columnMap.getOrDefault(column.getName().toLowerCase(), null);
             if (existingColumn == null || !existingColumn.getType().equals(column.getType())) {
                 return true;
             }
         }
         for (Column column : tableInput.getPartitionKeys()) {
-            Column existingPartitionKey = partitionKeyMap.getOrDefault(column.getName(), null);
+            Column existingPartitionKey = partitionKeyMap.getOrDefault(column.getName().toLowerCase(), null);
             if (existingPartitionKey == null || !existingPartitionKey.getType().equals(column.getType())) {
                 return true;
             }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
@@ -209,13 +209,14 @@ public class GlueMetastore implements IMetastore {
     }
     private List<Column> getListOfColumns(SinkRecord sinkRecord) {
         List<Column> columns= new ArrayList<>();
+//        log.info("Sink record schema {}", sinkRecord.valueSchema().fields());
         for (Field field: sinkRecord.valueSchema().fields()){
-            log.info("schema values {}", field);
             Column column= new Column();
             column.setName(field.name());
-            column.setType(GlueDataType.getDataType(field.schema().type()));
+            column.setType(GlueDataType.getDataType(field.schema()));
             columns.add(column);
         }
+//        log.info("New schema {}", columns);
         return columns;
     }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/GlueMetastore.java
@@ -1,10 +1,14 @@
 package io.confluent.connect.s3.metastore;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.amazonaws.services.glue.model.*;
 import org.apache.avro.Schema;
+import org.apache.commons.lang.ObjectUtils;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
@@ -28,68 +32,120 @@ public class GlueMetastore implements IMetastore {
     }
 
     @Override
-    public void updateMetastore(String name) {
+    public void updateMetastoreThroughCrawler(String name) {
         StartCrawlerResult startCrawlerResult = awsGlue.startCrawler(new StartCrawlerRequest().withName(name));
         String requestId = startCrawlerResult.getSdkResponseMetadata().getRequestId();
         log.info("Running Glue crawler, name : {}, requestId = {}", name, requestId);
     }
 
     @Override
-    public void updateMetastore(String name, SinkRecord sinkRecord){
+    public void updateMetastoreThroughGlueSdk(String name, SinkRecord sinkRecord, String s3Path, String partition){
         String[] parts = name.split("\\.");
-        log.info("testing update metastore");
-
+        List<Column>partitionKeys= getPartitionKeysUsingPartition(partition);
         String databaseName=parts[0];
-        String tableName= name.replace(".", "_");
-        List<Column> columns= getListOfColumns(sinkRecord);
-        StorageDescriptor storageDescriptor = new StorageDescriptor();
-        storageDescriptor.setSerdeInfo(new SerDeInfo());
-        storageDescriptor.setInputFormat("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat");
-        storageDescriptor.setOutputFormat("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat");
+        String tableName = name.replace(".", "_");
+        List<Column> columns = getListOfColumns(sinkRecord);
+        StorageDescriptor storageDescriptor = getDefaultStorageDescriptor();
         storageDescriptor.setColumns(columns);
-//        storageDescriptor.setLocation(buildS3Paths(databaseName,name));
-        if(checkIfTableExists(databaseName, tableName)){
-            log.info("Table exists");
-            awsGlue.updateTable(new UpdateTableRequest().withDatabaseName(databaseName)
-                    .withTableInput(new TableInput().withName(tableName).withStorageDescriptor(storageDescriptor)));
+        storageDescriptor.setLocation(buildS3Paths(s3Path,name));
+        TableInput tableInput=new TableInput().withName(tableName).withPartitionKeys(partitionKeys)
+                .withStorageDescriptor(storageDescriptor);
+        Table table =checkIfTableExists(databaseName, tableName);
+        if(table!=null){
+            if(checkIfUpdateRequired(table, tableInput)){
+                log.info("Table exists, updating table {}", tableName);
+                awsGlue.updateTable(new UpdateTableRequest().withDatabaseName(databaseName)
+                        .withTableInput(tableInput);
+            }
+
         } else {
-            log.info("Table does not exists");
-            awsGlue.createTable(new CreateTableRequest().withDatabaseName(databaseName).withTableInput(
-                    new TableInput().withName(tableName)
-                            .withStorageDescriptor(storageDescriptor.withLocation(buildS3Paths(databaseName, name)))));
+            log.info("Creating new table {}", tableName);
+            awsGlue.createTable(new CreateTableRequest().withDatabaseName(databaseName).withTableInput(tableInput));
         }
     }
 
-    private String buildS3Paths(String teamName, String path) {
-        return "s3://zinka-datalake-mumbai/" + teamName + '/' + path;
+    private Boolean checkIfUpdateRequired(Table table, TableInput tableInput) {
+        log.info("Table {}", table);
+        if (tableInput.getStorageDescriptor().getColumns().size() != table.getStorageDescriptor().getColumns().size()
+                || tableInput.getPartitionKeys().size() != table.getPartitionKeys().size()) {
+            return true;
+        }
+        if (!table.getStorageDescriptor().getLocation().equals(tableInput.getStorageDescriptor().getLocation())) {
+            return true;
+        }
+        Map<String, Column> columnMap = table.getStorageDescriptor().getColumns().stream()
+                .collect(Collectors.toMap(Column::getName, e -> e));
+        Map<String, Column> partitionKeyMap = table.getPartitionKeys().stream()
+                .collect(Collectors.toMap(Column::getName, e -> e));
+        for (Column column : tableInput.getStorageDescriptor().getColumns()) {
+            Column existingColumn = columnMap.getOrDefault(column.getName(), null);
+            if (existingColumn == null || !existingColumn.getType().equals(column.getType())) {
+                return true;
+            }
+        }
+        for (Column column : tableInput.getPartitionKeys()) {
+            Column existingPartitionKey = partitionKeyMap.getOrDefault(column.getName(), null);
+            if (existingPartitionKey == null || existingPartitionKey.getType().equals(column.getType())) {
+                return true;
+            }
+        }
+        log.info("No changes in glue table");
+        return false;
+    }
+
+    private List<Column> getPartitionKeysUsingPartition(String partition) {
+        String[] partitionSplit = partition.split(partitionDelim);
+
+        List<Column> keys = new ArrayList<>();
+        for (String partitionKey : partitionSplit) {
+            String[] keyValue = partitionKey.split(partitonKeyValueDelim);
+            String key = keyValue[0];
+            keys.add(new Column().withName(key).withType("string"));
+        }
+        return keys;
+    }
+
+    private List<String> getPartitionValuesUsingPartition(String partition) {
+        String[] partitionSplit = partition.split(partitionDelim);
+
+        List<String> values = new ArrayList<>();
+        for (String partitionKey : partitionSplit) {
+            String[] keyValue = partitionKey.split(partitonKeyValueDelim);
+            String value = keyValue[1];
+            values.add(value);
+        }
+        return values;
+    }
+
+    private String buildS3Paths(String s3BucketName, String path) {
+        return "s3://"+ s3BucketName + "/" + path+ "/";
     }
     private List<Column> getListOfColumns(SinkRecord sinkRecord) {
         List<Column> columns= new ArrayList<>();
         for (Field field: sinkRecord.valueSchema().fields()){
+            log.info("schema values {}", field);
             Column column= new Column();
             column.setName(field.name());
-            column.setType(field.schema().type().getName());
+            column.setType(GlueDataType.getDataType(field.schema().type()));
             columns.add(column);
         }
         return columns;
     }
 
-    private boolean checkIfTableExists(String databaseName, String tableName) {
-        boolean tableExists = false;
+    private Table checkIfTableExists(String databaseName, String tableName) {
         try {
-
-            awsGlue.getTable(new GetTableRequest()
+            return awsGlue.getTable(new GetTableRequest()
                     .withDatabaseName(databaseName)
-                    .withName(tableName));
+                    .withName(tableName)).getTable();
             // If the getTable request succeeds, the table exists
-            tableExists = true;
         } catch (Exception e) {
             if (e instanceof EntityNotFoundException){
-                tableExists = false;
+                log.info("Entity does not exist");
+                return null;
             }
             // If the getTable request throws a ResourceNotFoundException, the table does not exist
         }
-        return tableExists;
+        return null;
     }
 
     @Override
@@ -111,5 +167,33 @@ public class GlueMetastore implements IMetastore {
             log.info("error while fetching partition , e = ", e);
         }
         return false;
+    }
+
+    public void createPartition(String name, String s3Path, String partition){
+        String[] parts = name.split(topicNameDelim);
+        String tableName = name.replace(".", "_");
+        String databaseName=parts[0];
+        CreatePartitionRequest createPartitionRequest= new CreatePartitionRequest();
+        StorageDescriptor storageDescriptor= getDefaultStorageDescriptor();
+        log.info("Creating partition bucket {}", buildS3Paths(s3Path, name)+partition+"/");
+        storageDescriptor.setLocation(buildS3Paths(s3Path, name)+partition+"/");
+        createPartitionRequest.setDatabaseName(databaseName);
+        createPartitionRequest.setTableName(tableName);
+        createPartitionRequest.setPartitionInput(
+                new PartitionInput().withValues(getPartitionValuesUsingPartition(partition))
+                        .withStorageDescriptor(storageDescriptor));
+        awsGlue.createPartition(createPartitionRequest);
+    }
+
+    public StorageDescriptor getDefaultStorageDescriptor(){
+        StorageDescriptor storageDescriptor = new StorageDescriptor();
+        HashMap<String, String> parameters = new HashMap<>();
+        parameters.put("serialization.format", "1");
+        storageDescriptor.setSerdeInfo(
+                new SerDeInfo().withSerializationLibrary("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")
+                        .withParameters(parameters));
+        storageDescriptor.setInputFormat("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat");
+        storageDescriptor.setOutputFormat("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat");
+        return storageDescriptor;
     }
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/IMetastore.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/IMetastore.java
@@ -3,7 +3,8 @@ package io.confluent.connect.s3.metastore;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 public interface IMetastore  {
-    public void updateMetastore(String tableName);
+    public void updateMetastoreThroughCrawler(String tableName);
     public boolean isPartitionAvailable(String crawlerName, String partition);
-    public void updateMetastore(String tableName, SinkRecord sinkRecord);
+    public void updateMetastoreThroughGlueSdk(String tableName, SinkRecord sinkRecord, String s3Path, String partition);
+    public void createPartition(String name, String s3Path, String partition);
     }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/IMetastore.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/IMetastore.java
@@ -1,10 +1,17 @@
 package io.confluent.connect.s3.metastore;
 
+import com.amazonaws.services.glue.model.GetTableVersionsRequest;
+import com.amazonaws.services.glue.model.GetTableVersionsResult;
+import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.util.List;
 
 public interface IMetastore  {
     public void updateMetastoreThroughCrawler(String tableName);
     public boolean isPartitionAvailable(String crawlerName, String partition);
     public void updateMetastoreThroughGlueSdk(String tableName, SinkRecord sinkRecord, String s3Path, String partition);
     public void createPartition(String name, String s3Path, String partition);
-    }
+
+    public void deleteExcessGlueTableVersions(String name);
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/IMetastore.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/metastore/IMetastore.java
@@ -1,8 +1,9 @@
 package io.confluent.connect.s3.metastore;
 
+import org.apache.kafka.connect.sink.SinkRecord;
+
 public interface IMetastore  {
     public void updateMetastore(String tableName);
     public boolean isPartitionAvailable(String crawlerName, String partition);
-
-
+    public void updateMetastore(String tableName, SinkRecord sinkRecord);
     }


### PR DESCRIPTION
## Problem
Currently running glue crawler for updating glue tables causing more costs.

## Solution
Integrated glue sdk update table api's to reduce crawler costs.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
